### PR TITLE
Fix ESLint errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ var propertiesParser = require(`properties-parser`);
 var path = require(`path`);
 var FS = require(`q-io/fs`);
 var argv = require(`minimist`)(process.argv.slice(2));
-
 var Habitat = require(`habitat`);
+
 Habitat.load();
 
 var supportedLocales = process.env.SUPPORTED_LOCALES || `*`;
@@ -37,7 +37,7 @@ function getListLocales() {
         reject(e);
       });
     } else {
-      supportedLocales = supportedLocales.split(",").map(item => item.trim());
+      supportedLocales = supportedLocales.split(`,`).map(item => item.trim());
       resolve(supportedLocales);
     }
   });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "pontoon-to-json": "index.js"
   },
   "scripts": {
-    "test": "eslint --config ./.eslintrc.yaml '*.js'"
+    "test": "eslint ."
   },
   "keywords": [
     "Pontoon",


### PR DESCRIPTION
Fixed the following 2 errors:

```sh
$ npm test

> pontoon-to-json@2.0.0 test /Users/pdehaan/dev/github/mozilla/pontoon-to-json
> eslint --config ./.eslintrc.yaml '*.js'

/Users/pdehaan/dev/github/mozilla/pontoon-to-json/index.js
   8:1   error  Expected blank line after variable declarations  newline-after-var
  40:49  error  Strings must use backtick                        quotes

✖ 2 problems (2 errors, 0 warnings)

npm ERR! Test failed.  See above for more details.
```
